### PR TITLE
fix: preserve caret after consecutive Delete presses

### DIFF
--- a/packages/demo/e2e/review-delete.spec.ts
+++ b/packages/demo/e2e/review-delete.spec.ts
@@ -201,7 +201,7 @@ test("Delete removes one inserted character at an original-to-insertion boundary
   });
 });
 
-test("consecutive Delete presses mark consecutive original characters", async ({
+test("two Delete presses mark consecutive original characters as deleted", async ({
   page,
 }, testInfo) => {
   await openReviewEditorFixture(page);
@@ -226,10 +226,6 @@ test("consecutive Delete presses mark consecutive original characters", async ({
       segmentIndex: 0,
     });
 
-  test.fail(
-    testInfo.project.name === "firefox",
-    "Known Firefox selection-boundary issue: see #1.",
-  );
   await page.keyboard.press("Delete");
 
   const snapshots: Array<{

--- a/packages/lexical-review/src/ReviewSelection.ts
+++ b/packages/lexical-review/src/ReviewSelection.ts
@@ -24,6 +24,12 @@ function nodeDeleteByReviewType(
   isBackward: boolean,
   moveSelection: boolean,
 ) {
+  // Firefox can report a deleted node at the selection boundary without any
+  // selected text. Do not restore or otherwise mutate that zero-length node.
+  if (del <= 0) {
+    return;
+  }
+
   if (node.hasReviewType("insertion")) {
     // delete only part of text in <ins> tag
     node.deleteInsertionText(offset, del);
@@ -138,7 +144,15 @@ function suggestDeletion(selection: RangeSelection) {
       }
 
       // handle for last node
-      nodeDeleteByReviewType(lastNode, 0, lastPoint.offset, isBackward, false);
+      // Move forward deletions to the end of the newly marked text so a
+      // consecutive Delete starts from the expected caret position.
+      nodeDeleteByReviewType(
+        lastNode,
+        0,
+        lastPoint.offset,
+        isBackward,
+        !isBackward,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

- Ignore zero-length selection-boundary nodes when applying review deletion.
- Keep the caret at the end of forward deletions so repeated Delete presses remain consecutive.
- Promote the Firefox regression to a normal passing E2E test and clarify its name.

Fixes #1

## Validation

- `pnpm test --run`
- `pnpm typecheck:e2e`
- `pnpm lint`
- `pnpm test:e2e` — Chromium and Firefox, 4 passed