### PR TITLE
feat: preserve Lexical formatting inside review markup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Run `pnpm install` for local setup; CI uses `pnpm install --frozen-lockfile`. Th
 
 Use TypeScript/TSX, two-space indentation, and existing component/module conventions. Components and Lexical nodes use PascalCase (for example, `ReviewTextNode`); functions, hooks, and utilities use camelCase. Keep browser/editor-only code in the client entrypoint. Run `pnpm lint` and `pnpm prettier` before submitting changes.
 
+Review DOM invariant: insertion and deletion markers (`<ins>` and `<del>`) are the outermost wrappers; Lexical formatting and inline styles are nested inside them. Preserve this with real editor reconciliation tests.
+
 ## Testing Guidelines
 
 Add focused tests beside the implementation in `packages/lexical-review/src/`, using `*.spec.tsx` and descriptive `describe`/`it` blocks. Tests run with Vitest and jsdom. There is no configured coverage threshold; changes to node behavior, serialization, selection, or DOM rendering should include regression coverage.

--- a/packages/lexical-review/README.md
+++ b/packages/lexical-review/README.md
@@ -31,3 +31,9 @@ const initialConfig = {
 `ReviewTextPlugin` also normalizes ordinary text nodes created after registration to original review text. It throws during registration when `ReviewTextNode` is not registered.
 
 Please visit the [homepage](https://github.com/mahendrimd/lexical-review).
+
+## Rendering contract
+
+For inserted and deleted text, the review marker is always the outermost DOM
+element. Lexical formatting and inline styles are nested inside the marker,
+for example: `<ins><strong>inserted text</strong></ins>`.

--- a/packages/lexical-review/src/ReviewTextNode.ts
+++ b/packages/lexical-review/src/ReviewTextNode.ts
@@ -98,24 +98,28 @@ function setReviewTextThemeClassNames(
 ): void {
   addClassNamesToElement(dom, textClassNames.base);
 
-  const underlineStrikethroughClassName = textClassNames.underlineStrikethrough;
-  const prevUnderlineStrikethrough =
+  // Underline and strikethrough share the text-decoration CSS property. When
+  // a combined theme class is available, use it instead of competing
+  // individual classes.
+  const combinedDecorationClassName = textClassNames.underlineStrikethrough;
+  const previousHasCombinedDecoration =
     (prevFormat & IS_UNDERLINE) !== 0 && (prevFormat & IS_STRIKETHROUGH) !== 0;
-  const nextUnderlineStrikethrough =
+  const nextHasCombinedDecoration =
     (nextFormat & IS_UNDERLINE) !== 0 && (nextFormat & IS_STRIKETHROUGH) !== 0;
-  let hasUnderlineStrikethrough = false;
+  let usesCombinedDecorationClass = false;
 
-  if (underlineStrikethroughClassName !== undefined) {
-    if (nextUnderlineStrikethrough) {
-      hasUnderlineStrikethrough = true;
-      if (!prevUnderlineStrikethrough) {
-        addClassNamesToElement(dom, underlineStrikethroughClassName);
+  if (combinedDecorationClassName !== undefined) {
+    if (nextHasCombinedDecoration) {
+      usesCombinedDecorationClass = true;
+      if (!previousHasCombinedDecoration) {
+        addClassNamesToElement(dom, combinedDecorationClassName);
       }
-    } else if (prevUnderlineStrikethrough) {
-      removeClassNamesFromElement(dom, underlineStrikethroughClassName);
+    } else if (previousHasCombinedDecoration) {
+      removeClassNamesFromElement(dom, combinedDecorationClassName);
     }
   }
 
+  // Synchronize individual format classes after handling combined decoration.
   for (const formatName in TEXT_TYPE_TO_FORMAT) {
     const formatFlag = TEXT_TYPE_TO_FORMAT[formatName];
     const className = textClassNames[formatName];
@@ -124,25 +128,27 @@ function setReviewTextThemeClassNames(
       continue;
     }
 
-    if (nextFormat & formatFlag) {
-      if (
-        hasUnderlineStrikethrough &&
-        (formatName === "underline" || formatName === "strikethrough")
-      ) {
-        if (prevFormat & formatFlag) {
+    const wasActive = (prevFormat & formatFlag) !== 0;
+    const isActive = (nextFormat & formatFlag) !== 0;
+    const isTextDecorationFormat =
+      formatName === "underline" || formatName === "strikethrough";
+
+    if (isActive) {
+      if (usesCombinedDecorationClass && isTextDecorationFormat) {
+        if (wasActive) {
           removeClassNamesFromElement(dom, className);
         }
         continue;
       }
 
       if (
-        (prevFormat & formatFlag) === 0 ||
-        (prevUnderlineStrikethrough && formatName === "underline") ||
+        !wasActive ||
+        (previousHasCombinedDecoration && formatName === "underline") ||
         formatName === "strikethrough"
       ) {
         addClassNamesToElement(dom, className);
       }
-    } else if (prevFormat & formatFlag) {
+    } else if (wasActive) {
       removeClassNamesFromElement(dom, className);
     }
   }

--- a/packages/lexical-review/src/ReviewTextNode.ts
+++ b/packages/lexical-review/src/ReviewTextNode.ts
@@ -2,16 +2,27 @@ import {
   addClassNamesToElement,
   IS_FIREFOX,
   IS_IOS,
+  removeClassNamesFromElement,
   IS_SAFARI,
 } from "@lexical/utils";
 import {
   $applyNodeReplacement,
   EditorConfig,
+  IS_BOLD,
+  IS_CODE,
+  IS_HIGHLIGHT,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE,
   LexicalNode,
   NodeKey,
   SerializedTextNode,
   Spread,
+  TEXT_TYPE_TO_FORMAT,
   TextNode,
+  setDOMStyleFromCSS,
 } from "lexical";
 
 // all copied or modified from https://github.com/facebook/lexical/blob/8eae296ea39ff0dd707c901493553f1d889e9174/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -41,11 +52,7 @@ type SerializedReviewTextNodeV1 = Spread<
   SerializedTextNode
 >;
 
-// copy of getElementOuterTag - no support for tag code, sub, sup
-function getReviewElementOuterTag(
-  _node: ReviewTextNode,
-  review: number,
-): string | null {
+function getReviewElementOuterTag(review: number): string | null {
   if (review & IS_ADD) {
     return "ins";
   }
@@ -55,10 +62,110 @@ function getReviewElementOuterTag(
   return null;
 }
 
-// at this time, we do not allow for bold and italic review mode
-// so it is fine
-function getReviewElementInnerTag(): string {
+function getFormatElementOuterTag(format: number): string | null {
+  if (format & IS_CODE) {
+    return "code";
+  }
+  if (format & IS_HIGHLIGHT) {
+    return "mark";
+  }
+  if (format & IS_SUBSCRIPT) {
+    return "sub";
+  }
+  if (format & IS_SUPERSCRIPT) {
+    return "sup";
+  }
+  return null;
+}
+
+function getFormatElementInnerTag(format: number): string {
+  if (format & IS_BOLD) {
+    return "strong";
+  }
+  if (format & IS_ITALIC) {
+    return "em";
+  }
   return "span";
+}
+
+type TextThemeClasses = NonNullable<EditorConfig["theme"]["text"]>;
+
+function setReviewTextThemeClassNames(
+  prevFormat: number,
+  nextFormat: number,
+  dom: HTMLElement,
+  textClassNames: TextThemeClasses,
+): void {
+  addClassNamesToElement(dom, textClassNames.base);
+
+  const underlineStrikethroughClassName = textClassNames.underlineStrikethrough;
+  const prevUnderlineStrikethrough =
+    (prevFormat & IS_UNDERLINE) !== 0 && (prevFormat & IS_STRIKETHROUGH) !== 0;
+  const nextUnderlineStrikethrough =
+    (nextFormat & IS_UNDERLINE) !== 0 && (nextFormat & IS_STRIKETHROUGH) !== 0;
+  let hasUnderlineStrikethrough = false;
+
+  if (underlineStrikethroughClassName !== undefined) {
+    if (nextUnderlineStrikethrough) {
+      hasUnderlineStrikethrough = true;
+      if (!prevUnderlineStrikethrough) {
+        addClassNamesToElement(dom, underlineStrikethroughClassName);
+      }
+    } else if (prevUnderlineStrikethrough) {
+      removeClassNamesFromElement(dom, underlineStrikethroughClassName);
+    }
+  }
+
+  for (const formatName in TEXT_TYPE_TO_FORMAT) {
+    const formatFlag = TEXT_TYPE_TO_FORMAT[formatName];
+    const className = textClassNames[formatName];
+
+    if (formatFlag === undefined) {
+      continue;
+    }
+
+    if (nextFormat & formatFlag) {
+      if (
+        hasUnderlineStrikethrough &&
+        (formatName === "underline" || formatName === "strikethrough")
+      ) {
+        if (prevFormat & formatFlag) {
+          removeClassNamesFromElement(dom, className);
+        }
+        continue;
+      }
+
+      if (
+        (prevFormat & formatFlag) === 0 ||
+        (prevUnderlineStrikethrough && formatName === "underline") ||
+        formatName === "strikethrough"
+      ) {
+        addClassNamesToElement(dom, className);
+      }
+    } else if (prevFormat & formatFlag) {
+      removeClassNamesFromElement(dom, className);
+    }
+  }
+}
+
+function getReviewTextContentDOM(
+  element: HTMLElement,
+  review: number,
+  format: number,
+): HTMLElement {
+  let contentDOM = element;
+
+  if (getReviewElementOuterTag(review) !== null) {
+    contentDOM =
+      (contentDOM.firstElementChild as HTMLElement | null) ?? contentDOM;
+  }
+
+  if (getFormatElementOuterTag(format) !== null) {
+    contentDOM =
+      (contentDOM.firstElementChild as HTMLElement | null) ?? contentDOM;
+  }
+
+  return contentDOM;
 }
 
 // Reconciliation
@@ -133,20 +240,16 @@ function setReviewTextContent(
 function createReviewTextInnerDOM(
   innerDOM: HTMLElement,
   node: ReviewTextNode,
-  // innerTag: string,
-  // format: number,
+  format: number,
   text: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _config: EditorConfig,
+  config: EditorConfig,
 ): void {
   setReviewTextContent(text, innerDOM, node);
-  // const theme = config.theme;
-  // Apply theme class names
-  // const textClassNames = theme.text;
 
-  // if (textClassNames !== undefined) {
-  //   setTextThemeClassNames(innerTag, 0, format, innerDOM, textClassNames);
-  // }
+  const textClassNames = config.theme.text;
+  if (textClassNames !== undefined) {
+    setReviewTextThemeClassNames(0, format, innerDOM, textClassNames);
+  }
 }
 
 export class ReviewTextNode extends TextNode {
@@ -182,26 +285,40 @@ export class ReviewTextNode extends TextNode {
     return node;
   }
 
-  // mimic createDOM but without applying format
   override createDOM(config: EditorConfig): HTMLElement {
     const review = this.__review;
-    const outerTag = getReviewElementOuterTag(this, review);
-    const innerTag = getReviewElementInnerTag();
-    const tag = outerTag == null ? innerTag : outerTag;
+    const format = this.__format;
+    const reviewOuterTag = getReviewElementOuterTag(review);
+    const formatOuterTag = getFormatElementOuterTag(format);
+    const formatInnerTag = getFormatElementInnerTag(format);
+    const tag = reviewOuterTag ?? formatOuterTag ?? formatInnerTag;
     const dom = document.createElement(tag);
-    let innerDOM = dom;
-    if (outerTag !== null) {
-      innerDOM = document.createElement(innerTag);
-      dom.appendChild(innerDOM);
-
-      // add class to outer tag of ins and del
-      addClassNamesToElement(dom, config.theme[outerTag]);
+    let formatDOM = dom;
+    if (reviewOuterTag !== null) {
+      formatDOM = document.createElement(formatOuterTag ?? formatInnerTag);
+      dom.appendChild(formatDOM);
     }
+
+    let innerDOM = formatDOM;
+    if (formatOuterTag !== null) {
+      innerDOM = document.createElement(formatInnerTag);
+      formatDOM.appendChild(innerDOM);
+    }
+
+    if (format & IS_CODE) {
+      formatDOM.setAttribute("spellcheck", "false");
+    }
+
+    if (reviewOuterTag !== null) {
+      // add class to outer tag of ins and del
+      addClassNamesToElement(dom, config.theme[reviewOuterTag]);
+    }
+
     const text = this.__text;
-    createReviewTextInnerDOM(innerDOM, this, text, config);
+    createReviewTextInnerDOM(innerDOM, this, format, text, config);
     const style = this.__style;
     if (style !== "") {
-      dom.style.cssText = style;
+      setDOMStyleFromCSS(dom.style, style);
     }
 
     return dom;
@@ -209,38 +326,63 @@ export class ReviewTextNode extends TextNode {
 
   override getDOMSlot(element: HTMLElement) {
     const slot = super.getDOMSlot(element);
+    const contentDOM = getReviewTextContentDOM(
+      element,
+      this.__review,
+      this.__format,
+    );
 
-    if (getReviewElementOuterTag(this, this.__review) === null) {
-      return slot;
-    }
-
-    const innerDOM = element.firstElementChild as HTMLElement | null;
-    return innerDOM === null ? slot : slot.withElement(innerDOM);
+    return contentDOM === element ? slot : slot.withElement(contentDOM);
   }
 
-  // modify updateDOM
   override updateDOM(
     prevNode: ReviewTextNode,
     dom: HTMLElement,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _config: EditorConfig,
+    config: EditorConfig,
   ): boolean {
     const nextText = this.__text;
     const prevReview = prevNode.__review;
     const nextReview = this.__review;
-    const prevOuterTag = getReviewElementOuterTag(this, prevReview);
-    const nextOuterTag = getReviewElementOuterTag(this, nextReview);
-    const prevInnerTag = getReviewElementInnerTag(); //only output 'span'
-    const nextInnerTag = getReviewElementInnerTag(); //only output 'span'
-    const prevTag = prevOuterTag === null ? prevInnerTag : prevOuterTag;
-    const nextTag = nextOuterTag === null ? nextInnerTag : nextOuterTag;
+    const prevFormat = prevNode.__format;
+    const nextFormat = this.__format;
+    const prevReviewOuterTag = getReviewElementOuterTag(prevReview);
+    const nextReviewOuterTag = getReviewElementOuterTag(nextReview);
+    const prevFormatOuterTag = getFormatElementOuterTag(prevFormat);
+    const nextFormatOuterTag = getFormatElementOuterTag(nextFormat);
+    const prevFormatInnerTag = getFormatElementInnerTag(prevFormat);
+    const nextFormatInnerTag = getFormatElementInnerTag(nextFormat);
+    const prevTag =
+      prevReviewOuterTag ?? prevFormatOuterTag ?? prevFormatInnerTag;
+    const nextTag =
+      nextReviewOuterTag ?? nextFormatOuterTag ?? nextFormatInnerTag;
 
-    if (prevTag !== nextTag) {
+    if (
+      prevTag !== nextTag ||
+      prevReviewOuterTag !== nextReviewOuterTag ||
+      prevFormatOuterTag !== nextFormatOuterTag ||
+      prevFormatInnerTag !== nextFormatInnerTag
+    ) {
       return true;
     }
 
-    const innerDOM = this.getDOMSlot(dom).element;
+    const innerDOM = getReviewTextContentDOM(dom, nextReview, nextFormat);
     setReviewTextContent(nextText, innerDOM, this);
+
+    const textClassNames = config.theme.text;
+    if (textClassNames !== undefined && prevFormat !== nextFormat) {
+      setReviewTextThemeClassNames(
+        prevFormat,
+        nextFormat,
+        innerDOM,
+        textClassNames,
+      );
+    }
+
+    const prevStyle = prevNode.__style;
+    const nextStyle = this.__style;
+    if (prevStyle !== nextStyle) {
+      setDOMStyleFromCSS(dom.style, nextStyle, prevStyle);
+    }
 
     return false;
   }

--- a/packages/lexical-review/src/ReviewTextNode.ts
+++ b/packages/lexical-review/src/ReviewTextNode.ts
@@ -244,17 +244,17 @@ function setReviewTextContent(
 // exact copy
 // replacing TextNode - ReviewTextNode
 function createReviewTextInnerDOM(
-  innerDOM: HTMLElement,
+  contentDOM: HTMLElement,
   node: ReviewTextNode,
   format: number,
   text: string,
   config: EditorConfig,
 ): void {
-  setReviewTextContent(text, innerDOM, node);
+  setReviewTextContent(text, contentDOM, node);
 
   const textClassNames = config.theme.text;
   if (textClassNames !== undefined) {
-    setReviewTextThemeClassNames(0, format, innerDOM, textClassNames);
+    setReviewTextThemeClassNames(0, format, contentDOM, textClassNames);
   }
 }
 
@@ -299,6 +299,9 @@ export class ReviewTextNode extends TextNode {
     const formatInnerTag = getFormatElementInnerTag(format);
     const tag = reviewTag ?? formatOuterTag ?? formatInnerTag;
     const dom = document.createElement(tag);
+
+    // If there is no review marker, the root also serves as the format
+    // container.
     let formatDOM = dom;
     // Review markers must remain the outermost elements around Lexical
     // formatting, so inserted/deleted text renders as <ins>/<del> wrapping
@@ -308,10 +311,12 @@ export class ReviewTextNode extends TextNode {
       dom.appendChild(formatDOM);
     }
 
-    let innerDOM = formatDOM;
+    // If there is no outer format, the format container also serves as the
+    // deepest content element.
+    let contentDOM = formatDOM;
     if (formatOuterTag !== null) {
-      innerDOM = document.createElement(formatInnerTag);
-      formatDOM.appendChild(innerDOM);
+      contentDOM = document.createElement(formatInnerTag);
+      formatDOM.appendChild(contentDOM);
     }
 
     if (format & IS_CODE) {
@@ -324,7 +329,7 @@ export class ReviewTextNode extends TextNode {
     }
 
     const text = this.__text;
-    createReviewTextInnerDOM(innerDOM, this, format, text, config);
+    createReviewTextInnerDOM(contentDOM, this, format, text, config);
     const style = this.__style;
     if (style !== "") {
       setDOMStyleFromCSS(dom.style, style);
@@ -372,15 +377,15 @@ export class ReviewTextNode extends TextNode {
       return true;
     }
 
-    const innerDOM = getReviewTextContentDOM(dom, nextReview, nextFormat);
-    setReviewTextContent(nextText, innerDOM, this);
+    const contentDOM = getReviewTextContentDOM(dom, nextReview, nextFormat);
+    setReviewTextContent(nextText, contentDOM, this);
 
     const textClassNames = config.theme.text;
     if (textClassNames !== undefined && prevFormat !== nextFormat) {
       setReviewTextThemeClassNames(
         prevFormat,
         nextFormat,
-        innerDOM,
+        contentDOM,
         textClassNames,
       );
     }

--- a/packages/lexical-review/src/ReviewTextNode.ts
+++ b/packages/lexical-review/src/ReviewTextNode.ts
@@ -52,7 +52,7 @@ type SerializedReviewTextNodeV1 = Spread<
   SerializedTextNode
 >;
 
-function getReviewElementOuterTag(review: number): string | null {
+function getReviewElementTag(review: number): string | null {
   if (review & IS_ADD) {
     return "ins";
   }
@@ -155,7 +155,7 @@ function getReviewTextContentDOM(
 ): HTMLElement {
   let contentDOM = element;
 
-  if (getReviewElementOuterTag(review) !== null) {
+  if (getReviewElementTag(review) !== null) {
     contentDOM =
       (contentDOM.firstElementChild as HTMLElement | null) ?? contentDOM;
   }
@@ -288,13 +288,16 @@ export class ReviewTextNode extends TextNode {
   override createDOM(config: EditorConfig): HTMLElement {
     const review = this.__review;
     const format = this.__format;
-    const reviewOuterTag = getReviewElementOuterTag(review);
+    const reviewTag = getReviewElementTag(review);
     const formatOuterTag = getFormatElementOuterTag(format);
     const formatInnerTag = getFormatElementInnerTag(format);
-    const tag = reviewOuterTag ?? formatOuterTag ?? formatInnerTag;
+    const tag = reviewTag ?? formatOuterTag ?? formatInnerTag;
     const dom = document.createElement(tag);
     let formatDOM = dom;
-    if (reviewOuterTag !== null) {
+    // Review markers must remain the outermost elements around Lexical
+    // formatting, so inserted/deleted text renders as <ins>/<del> wrapping
+    // the format elements.
+    if (reviewTag !== null) {
       formatDOM = document.createElement(formatOuterTag ?? formatInnerTag);
       dom.appendChild(formatDOM);
     }
@@ -309,9 +312,9 @@ export class ReviewTextNode extends TextNode {
       formatDOM.setAttribute("spellcheck", "false");
     }
 
-    if (reviewOuterTag !== null) {
+    if (reviewTag !== null) {
       // add class to outer tag of ins and del
-      addClassNamesToElement(dom, config.theme[reviewOuterTag]);
+      addClassNamesToElement(dom, config.theme[reviewTag]);
     }
 
     const text = this.__text;
@@ -345,20 +348,18 @@ export class ReviewTextNode extends TextNode {
     const nextReview = this.__review;
     const prevFormat = prevNode.__format;
     const nextFormat = this.__format;
-    const prevReviewOuterTag = getReviewElementOuterTag(prevReview);
-    const nextReviewOuterTag = getReviewElementOuterTag(nextReview);
+    const prevReviewTag = getReviewElementTag(prevReview);
+    const nextReviewTag = getReviewElementTag(nextReview);
     const prevFormatOuterTag = getFormatElementOuterTag(prevFormat);
     const nextFormatOuterTag = getFormatElementOuterTag(nextFormat);
     const prevFormatInnerTag = getFormatElementInnerTag(prevFormat);
     const nextFormatInnerTag = getFormatElementInnerTag(nextFormat);
-    const prevTag =
-      prevReviewOuterTag ?? prevFormatOuterTag ?? prevFormatInnerTag;
-    const nextTag =
-      nextReviewOuterTag ?? nextFormatOuterTag ?? nextFormatInnerTag;
+    const prevTag = prevReviewTag ?? prevFormatOuterTag ?? prevFormatInnerTag;
+    const nextTag = nextReviewTag ?? nextFormatOuterTag ?? nextFormatInnerTag;
 
     if (
       prevTag !== nextTag ||
-      prevReviewOuterTag !== nextReviewOuterTag ||
+      prevReviewTag !== nextReviewTag ||
       prevFormatOuterTag !== nextFormatOuterTag ||
       prevFormatInnerTag !== nextFormatInnerTag
     ) {

--- a/packages/lexical-review/src/index.spec.tsx
+++ b/packages/lexical-review/src/index.spec.tsx
@@ -51,9 +51,18 @@ describe("Lexical Review Mode tests", () => {
           onError: onError || vitest.fn(),
           theme: {
             text: {
+              base: "editor-text-base",
               bold: "editor-text-bold",
+              capitalize: "editor-text-capitalize",
+              code: "editor-text-code",
+              highlight: "editor-text-highlight",
               italic: "editor-text-italic",
+              lowercase: "editor-text-lowercase",
+              strikethrough: "editor-text-strikethrough",
+              subscript: "editor-text-subscript",
+              superscript: "editor-text-superscript",
               underline: "editor-text-underline",
+              uppercase: "editor-text-uppercase",
             },
             ins: "review-insertion",
             del: "review-deletion",
@@ -253,6 +262,83 @@ describe("Lexical Review Mode tests", () => {
 
       expect(insTag?.classList.contains("review-insertion")).toBe(true);
       expect(delTag?.classList.contains("review-deletion")).toBe(true);
+    });
+
+    describe.each([
+      ["insertion", "INS"],
+      ["deletion", "DEL"],
+    ] as const)("%s markup", (reviewType, reviewTag) => {
+      it.each([
+        ["bold", "STRONG", null],
+        ["italic", "EM", null],
+        ["underline", "SPAN", null],
+        ["strikethrough", "SPAN", null],
+        ["highlight", "MARK", "SPAN"],
+        ["code", "CODE", "SPAN"],
+        ["subscript", "SUB", "SPAN"],
+        ["superscript", "SUP", "SPAN"],
+        ["lowercase", "SPAN", null],
+        ["uppercase", "SPAN", null],
+        ["capitalize", "SPAN", null],
+      ] as const)(
+        "renders %s formatting inside review markup",
+        async (format, outerTag, innerTag) => {
+          let reviewNode: ReviewTextNode;
+
+          await update(() => {
+            reviewNode = $createReviewTextNode("formatted", reviewType);
+            reviewNode.toggleFormat(format);
+            const paragraph = $createParagraphNode();
+            paragraph.append(reviewNode);
+            $getRoot().clear().append(paragraph);
+          });
+
+          const reviewDOM = editor.getElementByKey(reviewNode!.getKey());
+          const formattingDOM = reviewDOM?.firstElementChild as HTMLElement;
+          const contentDOM = (
+            innerTag === null ? formattingDOM : formattingDOM.firstElementChild
+          ) as HTMLElement;
+
+          expect(reviewDOM?.tagName).toBe(reviewTag);
+          expect(formattingDOM?.tagName).toBe(outerTag);
+          expect(contentDOM?.tagName).toBe(innerTag ?? outerTag);
+          expect(contentDOM?.textContent).toBe("formatted");
+          expect(contentDOM?.classList.contains(`editor-text-${format}`)).toBe(
+            true,
+          );
+          expect(reviewNode!.getDOMSlot(reviewDOM!).element).toBe(contentDOM);
+        },
+      );
+    });
+
+    it("reconciles inline styles and preserves formatting after text updates", async () => {
+      let reviewNode: ReviewTextNode;
+
+      await update(() => {
+        reviewNode = $createReviewTextNode("formatted", "insertion");
+        reviewNode.toggleFormat("italic");
+        reviewNode.setStyle("color: red; --custom: value;");
+        const paragraph = $createParagraphNode();
+        paragraph.append(reviewNode);
+        $getRoot().clear().append(paragraph);
+      });
+
+      const reviewDOM = editor.getElementByKey(reviewNode!.getKey());
+      expect(reviewDOM?.style.color).toBe("red");
+      expect(reviewDOM?.style.getPropertyValue("--custom")).toBe("value");
+
+      await update(() => {
+        reviewNode!.setStyle("padding: 1px;");
+        reviewNode!.setTextContent("updated");
+      });
+
+      const updatedReviewDOM = editor.getElementByKey(reviewNode!.getKey());
+      expect(updatedReviewDOM?.tagName).toBe("INS");
+      expect(updatedReviewDOM?.firstElementChild?.tagName).toBe("EM");
+      expect(updatedReviewDOM?.textContent).toBe("updated");
+      expect(updatedReviewDOM?.style.color).toBe("");
+      expect(updatedReviewDOM?.style.getPropertyValue("--custom")).toBe("");
+      expect(updatedReviewDOM?.style.padding).toBe("1px");
     });
 
     it("reconciles review text through the content slot", async () => {


### PR DESCRIPTION
## Summary

- Preserve Lexical text formatting and inline styles inside review markup.
- Keep `<ins>` and `<del>` as the outermost review markers.
- Add real editor reconciliation and rendered-DOM coverage for all supported formats and style updates.
- Document the DOM nesting invariant and clarify the reconciliation code.

## Validation

- `pnpm test --run`
- `pnpm --filter lexical-review build`
- `pnpm lint`
- `pnpm exec prettier --check packages/lexical-review/src/ReviewTextNode.ts`

Closes #7