### PR TITLE
ci: migrate pnpm action to node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/package-contract.yml
+++ b/.github/workflows/package-contract.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 


### PR DESCRIPTION
## Summary

- upgrade `pnpm/action-setup` from `v4` to `v6` in all repository workflows
- use the action release that declares the Node.js 24 runtime
- preserve the repository's pnpm `11.21.0` CLI, Node.js 24 jobs, cache settings, frozen installs, and workflow commands

Closes #22
Related to #12

## Validation

- `pnpm install --frozen-lockfile` — passed
- `pnpm test --run` — passed (68 tests)
- `pnpm test:package` — passed
- `pnpm --filter demo build` — passed
- `pnpm lint` — passed
- Prettier check for all workflow files — passed
- `pnpm build:demo` through Nx could not start its plugin worker in this environment; the underlying demo build completed successfully when run directly
