### PR TITLE
chore(ci): upgrade GitHub Actions and migrate pnpm setup

### DIFF
--- a/.github/workflows/lexical-compatibility.yml
+++ b/.github/workflows/lexical-compatibility.yml
@@ -37,18 +37,14 @@ jobs:
       e2eMatrix: ${{ steps.resolve.outputs.e2eMatrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -71,18 +67,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Run compatibility checks
         run: pnpm compatibility -- --version "${{ matrix.version }}"
@@ -99,18 +91,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Run browser compatibility checks
         env:
@@ -123,7 +111,7 @@ jobs:
 
       - name: Upload Playwright diagnostics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-${{ matrix.lexicalVersion }}-${{ matrix.reactVersion }}-${{ matrix.project }}
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,18 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: "pnpm"
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -45,14 +41,14 @@ jobs:
         run: pnpm build:demo
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload dist folder
           path: "./packages/demo/dist"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/package-contract.yml
+++ b/.github/workflows/package-contract.yml
@@ -15,18 +15,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -12,19 +12,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-          registry-url: https://registry.npmjs.org
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies Frozen
         run: pnpm --filter lexical-review install --frozen-lockfile
@@ -33,4 +28,6 @@ jobs:
         run: pnpm --filter lexical-review build
 
       - name: Publish to NPM registry
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
         run: pnpm publish packages/lexical-review --access public --no-git-checks --provenance


### PR DESCRIPTION
## Summary

Closes #29.

- Upgrade checkout, artifact, and Pages actions to the current audited majors.
- Replace pnpm/action-setup and actions/setup-node with pnpm/setup@v2.
- Install the declared pnpm 11 toolchain with runtime node@24, pnpm caching, and explicit frozen-lockfile installs preserved.
- Preserve the npm publish registry through NPM_CONFIG_REGISTRY.

## Validation

- pnpm prettier:check
- pnpm lint
- pnpm test --run — 88 tests passed
- pnpm build:demo
- pnpm test:package
- git diff --check
- Confirmed no pnpm/action-setup, actions/setup-node, run_install, node-version, or registry-url references remain in the workflows.

actionlint was not installed locally; workflow YAML was parsed and formatted by Prettier, and the direct action-reference checks passed.
